### PR TITLE
Feature1 - Favorite Artists - Fix-Prevent Duplicate Favorite Artists

### DIFF
--- a/app/src/main/java/com/example/group_10_melody_match/data/database/dao/ArtistDao.java
+++ b/app/src/main/java/com/example/group_10_melody_match/data/database/dao/ArtistDao.java
@@ -45,4 +45,10 @@ public interface ArtistDao {
      */
     @Query("DELETE FROM artists")
     void deleteAll();
+
+    /**
+     * Check if artist exists by name
+     */
+    @Query("SELECT COUNT(*) FROM artists WHERE name = :name")
+    int getArtistCountByName(String name);
 }

--- a/app/src/main/java/com/example/group_10_melody_match/data/repository/ArtistRepository.java
+++ b/app/src/main/java/com/example/group_10_melody_match/data/repository/ArtistRepository.java
@@ -72,4 +72,19 @@ public class ArtistRepository {
             artistDao.deleteAll();
         });
     }
+
+    /**
+     * Check if artist exists
+     */
+    public boolean artistExists(String name) {
+        // Using a simple way to get the result synchronously
+        try {
+            return executorService.submit(() -> 
+                artistDao.getArtistCountByName(name) > 0
+            ).get();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
 }

--- a/app/src/main/java/com/example/group_10_melody_match/ui/activity/AddArtistActivity.java
+++ b/app/src/main/java/com/example/group_10_melody_match/ui/activity/AddArtistActivity.java
@@ -116,6 +116,15 @@ public class AddArtistActivity extends AppCompatActivity implements AvailableArt
      */
     @Override
     public void onArtistAdd(AvailableArtist availableArtist) {
+        // Check if artist already exists
+        if (artistRepository.artistExists(availableArtist.getName())) {
+            // Show error message
+            Toast.makeText(this, 
+                getString(R.string.artist_already_exists, availableArtist.getName()), 
+                Toast.LENGTH_SHORT).show();
+            return;
+        }
+
         // Convert AvailableArtist to Artist
         Artist artist = new Artist(
                 0, // ID will be auto-generated

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="available_artists">Available Artists</string>
     <string name="artist_added">%s added to favorites</string>
     <string name="artist_removed">Artist removed from favorites</string>
+    <string name="artist_already_exists">%1$s is already in your favorites</string>
 </resources>


### PR DESCRIPTION

This PR addresses an issue where users could accidentally add the same artist multiple times to their favorite artists list. The changes ensure that duplicate favorite artists are prevented by performing a check before adding a new artist.
Changes Made
AddArtistActivity:
Updated the onArtistAdd method to check if an artist already exists in the favorites list by calling artistRepository.artistExists().
If the artist exists, a toast message is displayed to notify the user, and the addition is aborted.
ArtistRepository:
Added a new synchronous method artistExists(String name) that checks against the database if an artist is already present using ArtistDao.getArtistCountByName(String name).
ArtistDao:
Introduced a new query method getArtistCountByName(String name) to count the occurrences of an artist by name, enabling the duplicate check.
String Resources:
Added a new string resource artist_already_exists to provide user feedback when attempting to add a duplicate artist.
Testing
Verified that when trying to add an artist who is already in the favorites, the app displays an appropriate message and does not add the duplicate.
Confirmed that adding a new, non-duplicate artist works as expected.

fix #4 